### PR TITLE
fix: download all artifacts as there is only one

### DIFF
--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -16,7 +16,6 @@ jobs:
     - name: Download Artifacts
       uses: actions/download-artifact@v4
       with:
-        name: build
         path: ./frontend/build/
 
     - name: Push to deployment


### PR DESCRIPTION
Removing the name downloads all the artifacts associated with it