### PR TITLE
Make deploys independent of build artifact

### DIFF
--- a/.github/workflows/build-ci-test.yaml
+++ b/.github/workflows/build-ci-test.yaml
@@ -45,10 +45,3 @@ jobs:
         cd frontend
         pnpm run build
 
-    - name: Save build artifacts
-      if: success()
-      uses: actions/upload-artifact@v4
-      with:
-        name: build
-        path: ./frontend/dist
-

--- a/.github/workflows/deploy-gh-pages.yaml
+++ b/.github/workflows/deploy-gh-pages.yaml
@@ -37,13 +37,10 @@ jobs:
         cd frontend
         pnpm install
     
-    - name: Download Artifacts
-      id: download-artifact
-      uses: dawidd6/action-download-artifact@v5
-      with:
-        workflow: build-ci-test.yaml
-        github_token: ${{secrets.GITHUB_TOKEN}}
-        path: ./frontend/
+    - name: Build the application
+      run: |
+        cd frontend
+        pnpm run build
 
     - name: Deploy 🚀
       uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
# Description

Deploy for PR #89 failed because the existing workflows for build and deploy were dependent, the `build-ci-test` workflow (which runs on PRs) generated a build artifact, which then was downloaded by the `deploy-gh-pages` workflow, when it ran (on push). However in the above case, the deploy workflow could not download the artifact, since the build workflow ran on a fork of the repo, not the main repo itself.

This PR changes the workflows to not upload/download artifact, and instead perform repeated builds, once in the `build-ci-test` workflow, and once more in the `deploy-gh-pages` workflow.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
